### PR TITLE
give correct namespace to RequestException

### DIFF
--- a/pybitflyer/pybitflyer.py
+++ b/pybitflyer/pybitflyer.py
@@ -52,7 +52,7 @@ class API(object):
                     response = s.post(url, data=json.dumps(params))
         except requests.RequestException as e:
             print(e)
-            sys.exit(1)
+            raise e
 
         content = ""
         if len(response.content) > 0:

--- a/pybitflyer/pybitflyer.py
+++ b/pybitflyer/pybitflyer.py
@@ -50,7 +50,7 @@ class API(object):
                     response = s.get(url, params=params)
                 else:  # method == "POST":
                     response = s.post(url, data=json.dumps(params))
-        except RequestException as e:
+        except requests.RequestException as e:
             print(e)
             sys.exit(1)
 


### PR DESCRIPTION
I fixed a NameError of `RequestException`.

But basically, I don't think its good to catch the exception here and exit the process, because I just want to ignore the response if the error is raised. 


