### PR TITLE
Fix signing error when GET request

### DIFF
--- a/pybitflyer/pybitflyer.py
+++ b/pybitflyer/pybitflyer.py
@@ -48,7 +48,7 @@ class API(object):
                     s.headers.update(auth_header)
 
                 if method == "GET":
-                    response = s.get(url, params=params, timeout=self.timeout)
+                    response = s.get(url + body, timeout=self.timeout)
                 else:  # method == "POST":
                     response = s.post(url, data=json.dumps(params), timeout=self.timeout)
         except requests.RequestException as e:


### PR DESCRIPTION
Fixed signing errors occurring on GET request.
If `params` argument is used, the order of query string may differ from before the hashing (https://github.com/nohtaray/pybitflyer/blob/0a5c53dc12104f76199c672d84eab6d2f3971769/pybitflyer/pybitflyer.py#L33).
