### PR TITLE
make API instance keep session object for HTTP keep-alive

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,8 @@ Usage
 .. code:: python
 
   import pybitflyer
-  api = pybitflyer.API(api_key="xxx...", api_secret="yyy...")
+  with pybitflyer.API(api_key="xxx...", api_secret="yyy...") as api:
+      # call some methods shown below
 
 If you use HTTP Public API, API Key and API Secret can be omitted.
 

--- a/pybitflyer/pybitflyer.py
+++ b/pybitflyer/pybitflyer.py
@@ -18,6 +18,12 @@ class API(object):
         self.api_secret = api_secret
         self.sess = requests.Session()
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+
     def close(self):
         self.sess.close()
 

--- a/pybitflyer/pybitflyer.py
+++ b/pybitflyer/pybitflyer.py
@@ -11,12 +11,13 @@ from .exception import AuthException
 
 class API(object):
 
+    api_url = "https://api.bitflyer.jp"
+
     def __init__(self, api_key=None, api_secret=None):
-        self.api_url = "https://api.bitflyer.jp"
         self.api_key = api_key
         self.api_secret = api_secret
 
-    def request(self, endpoint, method="GET", params=None):
+    def _request(self, endpoint, method="GET", params=None):
         url = self.api_url + endpoint
         body = ""
         auth_header = None
@@ -52,7 +53,7 @@ class API(object):
                     response = s.post(url, data=json.dumps(params))
         except requests.RequestException as e:
             print(e)
-            raise e
+            raise
 
         content = ""
         if len(response.content) > 0:
@@ -78,7 +79,7 @@ class API(object):
         https://lightning.bitflyer.jp/docs?lang=en#order-book
         """
         endpoint = "/v1/board"
-        return self.request(endpoint, params=params)
+        return self._request(endpoint, params=params)
 
     def ticker(self, **params):
         """Ticker
@@ -96,7 +97,7 @@ class API(object):
         https://lightning.bitflyer.jp/docs?lang=en#ticker
         """
         endpoint = "/v1/ticker"
-        return self.request(endpoint, params=params)
+        return self._request(endpoint, params=params)
 
     def executions(self, **params):
         """Execution History
@@ -115,7 +116,7 @@ class API(object):
         https://lightning.bitflyer.jp/docs?lang=en#execution-history
         """
         endpoint = "/v1/executions"
-        return self.request(endpoint, params=params)
+        return self._request(endpoint, params=params)
 
     def gethealth(self, **params):
         """Exchange status
@@ -143,7 +144,7 @@ class API(object):
         https://lightning.bitflyer.jp/docs?lang=en#exchange-status
         """
         endpoint = "/v1/gethealth"
-        return self.request(endpoint, params=params)
+        return self._request(endpoint, params=params)
 
     def getchats(self, **params):
         """ Chat
@@ -162,7 +163,7 @@ class API(object):
         https://lightning.bitflyer.jp/docs?lang=en#chat
         """
         endpoint = "/v1/getchats"
-        return self.request(endpoint, params=params)
+        return self._request(endpoint, params=params)
 
     """HTTP Private API"""
 
@@ -181,7 +182,7 @@ class API(object):
             raise AuthException()
 
         endpoint = "/v1/me/getbalance"
-        return self.request(endpoint, params=params)
+        return self._request(endpoint, params=params)
 
     def getcollateral(self, **params):
         """Get Margin Status
@@ -205,7 +206,7 @@ class API(object):
             raise AuthException()
 
         endpoint = "/v1/me/getcollateral"
-        return self.request(endpoint, params=params)
+        return self._request(endpoint, params=params)
 
     def getcollateralhistory(self, **params):
         """Get Margin Change History
@@ -229,7 +230,7 @@ class API(object):
             raise AuthException()
 
         endpoint = "/v1/me/getcollateralhistory"
-        return self.request(endpoint, params=params)
+        return self._request(endpoint, params=params)
 
     def getaddresses(self, **params):
         """Get Bitcoin/Ethereum Deposit Addresses
@@ -251,7 +252,7 @@ class API(object):
             raise AuthException()
 
         endpoint = "/v1/me/getaddresses"
-        return self.request(endpoint, params=params)
+        return self._request(endpoint, params=params)
 
     def getcoinins(self, **params):
         """Get Bitcoin/Ether Deposit History
@@ -276,7 +277,7 @@ class API(object):
             raise AuthException()
 
         endpoint = "/v1/me/getcoinins"
-        return self.request(endpoint, params=params)
+        return self._request(endpoint, params=params)
 
     def sendcoin(self, **params):
         """Bitcoin/Ethereum External Delivery
@@ -314,7 +315,7 @@ class API(object):
             raise AuthException()
 
         endpoint = "/v1/me/sendcoin"
-        return self.request(endpoint, "POST", params=params)
+        return self._request(endpoint, "POST", params=params)
 
     def getcoinouts(self, **params):
         """Get Bitcoin/Ether Transaction History
@@ -340,7 +341,7 @@ class API(object):
             raise AuthException()
 
         endpoint = "/v1/me/getcoinouts"
-        return self.request(endpoint, params=params)
+        return self._request(endpoint, params=params)
 
     def getbankaccounts(self, **params):
         """Get Summary of Bank Accounts
@@ -363,7 +364,7 @@ class API(object):
             raise AuthException()
 
         endpoint = "/v1/me/getbankaccounts"
-        return self.request(endpoint, params=params)
+        return self._request(endpoint, params=params)
 
     def getdeposits(self, **params):
         """Get Cash Deposits
@@ -388,7 +389,7 @@ class API(object):
             raise AuthException()
 
         endpoint = "/v1/me/getdeposits"
-        return self.request(endpoint, params=params)
+        return self._request(endpoint, params=params)
 
     def withdraw(self, **params):
         """Cancelling deposits
@@ -419,7 +420,7 @@ class API(object):
             raise AuthException()
 
         endpoint = "/v1/me/withdraw"
-        return self.request(endpoint, "POST", params=params)
+        return self._request(endpoint, "POST", params=params)
 
     def getwithdrawals(self, **params):
         """Get Deposit Cancellation History
@@ -444,7 +445,7 @@ class API(object):
             raise AuthException()
 
         endpoint = "/v1/me/getwithdrawals"
-        return self.request(endpoint, params=params)
+        return self._request(endpoint, params=params)
 
     def sendchildorder(self, **params):
         """Send a New Order
@@ -477,7 +478,7 @@ class API(object):
             raise AuthException()
 
         endpoint = "/v1/me/sendchildorder"
-        return self.request(endpoint, "POST", params=params)
+        return self._request(endpoint, "POST", params=params)
 
     def cancelchildorder(self, **params):
         """Cancel Order
@@ -506,7 +507,7 @@ class API(object):
             raise AuthException()
 
         endpoint = "/v1/me/cancelchildorder"
-        return self.request(endpoint, "POST", params=params)
+        return self._request(endpoint, "POST", params=params)
 
     def sendparentorder(self, **params):
         """Submit New Parent Order (Special order)
@@ -562,7 +563,7 @@ class API(object):
             raise AuthException()
 
         endpoint = "/v1/me/sendparentorder"
-        return self.request(endpoint, "POST", params=params)
+        return self._request(endpoint, "POST", params=params)
 
     def cancelparentorder(self, **params):
         """Cancel parent order
@@ -592,7 +593,7 @@ class API(object):
             raise AuthException()
 
         endpoint = "/v1/me/cancelparentorder"
-        return self.request(endpoint, "POST", params=params)
+        return self._request(endpoint, "POST", params=params)
 
     def cancelallchildorders(self, **params):
         """Cancel All Orders
@@ -617,7 +618,7 @@ class API(object):
             raise AuthException()
 
         endpoint = "/v1/me/cancelallchildorders"
-        return self.request(endpoint, "POST", params=params)
+        return self._request(endpoint, "POST", params=params)
 
     def getchildorders(self, **params):
         """List Orders
@@ -646,7 +647,7 @@ class API(object):
             raise AuthException()
 
         endpoint = "/v1/me/getchildorders"
-        return self.request(endpoint, params=params)
+        return self._request(endpoint, params=params)
 
     def getparentorders(self, **params):
         """List Parent Orders
@@ -680,7 +681,7 @@ class API(object):
             raise AuthException()
 
         endpoint = "/v1/me/getparentorders"
-        return self.request(endpoint, params=params)
+        return self._request(endpoint, params=params)
 
     def getparentorder(self, **params):
         """Get Parent Order Details
@@ -706,7 +707,7 @@ class API(object):
             raise AuthException()
 
         endpoint = "/v1/me/getparentorder"
-        return self.request(endpoint, params=params)
+        return self._request(endpoint, params=params)
 
     def getexecutions(self, **params):
         """List Executions
@@ -730,7 +731,7 @@ class API(object):
             raise AuthException()
 
         endpoint = "/v1/me/getexecutions"
-        return self.request(endpoint, params=params)
+        return self._request(endpoint, params=params)
 
     def getpositions(self, **params):
         """
@@ -751,7 +752,7 @@ class API(object):
             raise AuthException()
 
         endpoint = "/v1/me/getpositions"
-        return self.request(endpoint, params=params)
+        return self._request(endpoint, params=params)
 
     def gettradingcommission(self, **params):
         """
@@ -772,4 +773,4 @@ class API(object):
             raise AuthException()
 
         endpoint = "/v1/me/gettradingcommission"
-        return self.request(endpoint, params=params)
+        return self._request(endpoint, params=params)

--- a/pybitflyer/pybitflyer.py
+++ b/pybitflyer/pybitflyer.py
@@ -16,6 +16,10 @@ class API(object):
     def __init__(self, api_key=None, api_secret=None):
         self.api_key = api_key
         self.api_secret = api_secret
+        self.sess = requests.Session()
+
+    def close(self):
+        self.sess.close()
 
     def _request(self, endpoint, method="GET", params=None):
         url = self.api_url + endpoint
@@ -43,14 +47,13 @@ class API(object):
             }
 
         try:
-            with requests.Session() as s:
-                if auth_header:
-                    s.headers.update(auth_header)
+            if auth_header:
+                self.sess.headers.update(auth_header)
 
-                if method == "GET":
-                    response = s.get(url, params=params)
-                else:  # method == "POST":
-                    response = s.post(url, data=json.dumps(params))
+            if method == "GET":
+                response = self.sess.get(url, params=params)
+            else:  # method == "POST":
+                response = self.sess.post(url, data=json.dumps(params))
         except requests.RequestException as e:
             print(e)
             raise


### PR DESCRIPTION
To enable HTTP keep-alive over multiple requests, I would like to propose this pull request (including some minor changes).