### PR TITLE
Add timeout

### DIFF
--- a/pybitflyer/pybitflyer.py
+++ b/pybitflyer/pybitflyer.py
@@ -11,10 +11,11 @@ from .exception import AuthException
 
 class API(object):
 
-    def __init__(self, api_key=None, api_secret=None):
+    def __init__(self, api_key=None, api_secret=None, timeout=None):
         self.api_url = "https://api.bitflyer.jp"
         self.api_key = api_key
         self.api_secret = api_secret
+        self.timeout = timeout
 
     def request(self, endpoint, method="GET", params=None):
         url = self.api_url + endpoint
@@ -47,9 +48,9 @@ class API(object):
                     s.headers.update(auth_header)
 
                 if method == "GET":
-                    response = s.get(url, params=params)
+                    response = s.get(url, params=params, timeout=self.timeout)
                 else:  # method == "POST":
-                    response = s.post(url, data=json.dumps(params))
+                    response = s.post(url, data=json.dumps(params), timeout=self.timeout)
         except requests.RequestException as e:
             print(e)
             raise e


### PR DESCRIPTION
Occasionally API server does not respond and it causes hang up until the connection is closed. So I added `timeout` option for requests.
```
api = pybitflyer.API(timeout=20)
```
When `timeout` is specified, it may raise an exception `requests.exceptions.ConnectTimeout` / `requests.exceptions.ReadTimeout`.
The default value for `timeout` is `None`, it does not break backwards compatibility.
