### PR TITLE
Return full response for status code checking

### DIFF
--- a/pybitflyer/pybitflyer.py
+++ b/pybitflyer/pybitflyer.py
@@ -58,6 +58,8 @@ class API(object):
         content = ""
         if len(response.content) > 0:
             content = json.loads(response.content.decode("utf-8"))
+        else:
+            content = response
 
         return content
 


### PR DESCRIPTION
Some bitFlyer API calls (such as cancels) return an empty response with a 200 status code if successful.  In this case, the full response should be returned so one can check the status code for success confirmation.